### PR TITLE
Ref #16 - prevent menu to dissapear in Safari/Firefox

### DIFF
--- a/src/components/ContextMenu.js
+++ b/src/components/ContextMenu.js
@@ -51,11 +51,10 @@ class ContextMenu extends Component {
   }
 
   bindWindowEvent = () => {
-    // Do not subscribe to click here.
-    // Some browsers trigger a click event causing the menu to get closed
     window.addEventListener('resize', this.hide);
     window.addEventListener('contextmenu', this.hide);
     window.addEventListener('mousedown', this.hide);
+    window.addEventListener('click', this.hide);
     window.addEventListener('scroll', this.hide);
     window.addEventListener('keydown', this.handleKeyboard);
   };
@@ -69,17 +68,18 @@ class ContextMenu extends Component {
     window.removeEventListener('keydown', this.handleKeyboard);
   };
 
-  onMouseEnter = () => {
-    // Do not subscribe to click until the menu is open
-    // Some browsers trigger a click event causing the menu to get closed
-    window.addEventListener('click', this.hide);
-    //
-    window.removeEventListener('mousedown', this.hide);
-  }
+  onMouseEnter = () => window.removeEventListener('mousedown', this.hide);
 
   onMouseLeave = () => window.addEventListener('mousedown', this.hide);
 
   hide = e => {
+      if (typeof e !== 'undefined' && e.button === 2 && e.type !== 'contextmenu') {
+        return;
+      }
+      // Safari trigger a click event when you ctrl + trackpad
+      if (typeof e !== 'undefined' && e.ctrlKey === true && e.type !== 'contextmenu') {
+        return;
+      }
       this.unBindWindowEvent();
       this.setState({ visible: false });
   };

--- a/src/components/ContextMenu.js
+++ b/src/components/ContextMenu.js
@@ -51,10 +51,11 @@ class ContextMenu extends Component {
   }
 
   bindWindowEvent = () => {
+    // Do not subscribe to click here.
+    // Some browsers trigger a click event causing the menu to get closed
     window.addEventListener('resize', this.hide);
     window.addEventListener('contextmenu', this.hide);
     window.addEventListener('mousedown', this.hide);
-    window.addEventListener('click', this.hide);
     window.addEventListener('scroll', this.hide);
     window.addEventListener('keydown', this.handleKeyboard);
   };
@@ -68,19 +69,17 @@ class ContextMenu extends Component {
     window.removeEventListener('keydown', this.handleKeyboard);
   };
 
-  onMouseEnter = () => window.removeEventListener('mousedown', this.hide);
+  onMouseEnter = () => {
+    // Do not subscribe to click until the menu is open
+    // Some browsers trigger a click event causing the menu to get closed
+    window.addEventListener('click', this.hide);
+    //
+    window.removeEventListener('mousedown', this.hide);
+  }
 
   onMouseLeave = () => window.addEventListener('mousedown', this.hide);
 
   hide = e => {
-      // Firefox trigger a click event when you mouse up on contextmenu event
-      if (
-        typeof e !== 'undefined' &&
-        e.button === 2 &&
-        e.type !== 'contextmenu'
-      ) {
-        return;
-      }
       this.unBindWindowEvent();
       this.setState({ visible: false });
   };


### PR DESCRIPTION
If the user Right-click using ctrl + trackpad-click in Safari the menu will be closed right after opening. This is because Safari triggers click event. The problem was previously fixed for Firefox but not for this scenario because the event button reference is different.