### PR TITLE
Add hidden prop to Item component

### DIFF
--- a/src/__playground__/components/App.tsx
+++ b/src/__playground__/components/App.tsx
@@ -44,6 +44,8 @@ const MyAwesomeMenu: React.SFC<{
       Foo
     </Item>
     <Item onClick={onClick}>Ipsum</Item>
+    <Item hidden>Foo</Item>
+    <Item hidden={() => true}>Bar</Item>
     <Item disabled>Sit</Item>
     {null}
     <Separator />

--- a/src/__tests__/components/Item.tsx
+++ b/src/__tests__/components/Item.tsx
@@ -53,7 +53,25 @@ describe('Menu Item', () => {
     expect(click).not.toHaveBeenCalled();
   });
 
-  it('Should allow disabled props to be a function', () => {
+  it('Should not render when hidden', () => {
+    const component = shallow(<Item hidden>foo</Item>);
+    expect(component.html()).toBeNull();
+  });
+
+  it('Should allow hidden prop to be a function', () => {
+    const mock = jest.fn();
+    const hidden = () => {
+      mock();
+      return true;
+    };
+
+    const component = shallow(<Item hidden={hidden}>foo</Item>);
+
+    expect(mock).toHaveBeenCalled();
+    expect(component.html()).toBeNull();
+  });
+
+  it('Should allow disabled prop to be a function', () => {
     const mock = jest.fn();
     const disabled = () => {
       mock();

--- a/src/__tests__/components/__snapshots__/Menu.tsx.snap
+++ b/src/__tests__/components/__snapshots__/Menu.tsx.snap
@@ -43,6 +43,7 @@ exports[`Menu Should remove null Item from menu 1`] = `
         <div>
           <Item
             disabled={false}
+            hidden={false}
             key=".$.0"
             nativeEvent={Object {}}
             onClick={[Function]}

--- a/src/components/Item.tsx
+++ b/src/components/Item.tsx
@@ -69,13 +69,13 @@ class Item extends Component<ItemProps> {
     super(props);
     const { disabled, hidden, nativeEvent, propsFromTrigger, data } = this.props;
 
-    const getBooleanPredicateValue = (predicateFunc: BooleanPredicate) => {
-      return typeof predicateFunc === 'function'
-        ? predicateFunc({
+    const getBooleanPredicateValue = (predicate: BooleanPredicate) => {
+      return typeof predicate === 'function'
+        ? predicate({
             event: nativeEvent as TriggerEvent,
             props: { ...propsFromTrigger, ...data }
           })
-        : predicateFunc;
+        : predicate;
     }
 
     this.isDisabled = getBooleanPredicateValue(disabled)

--- a/src/components/Item.tsx
+++ b/src/components/Item.tsx
@@ -10,6 +10,8 @@ import {
   InternalProps
 } from '../types';
 
+type BooleanPredicate = boolean | ((args: MenuItemEventHandler) => boolean)
+
 export interface ItemProps extends StyleProps, InternalProps {
   /**
    * Any valid node that can be rendered
@@ -24,12 +26,12 @@ export interface ItemProps extends StyleProps, InternalProps {
   /**
    * Disable or not the `Item`. If a function is used, a boolean must be returned
    */
-  disabled: boolean | ((args: MenuItemEventHandler) => boolean);
+  disabled: BooleanPredicate;
 
   /**
    * Hide or not the `Item`. If a function is used, a boolean must be returned
    */
-  hidden: boolean | ((args: MenuItemEventHandler) => boolean);
+  hidden: BooleanPredicate;
 
   /**
    * Callback when the current `Item` is clicked. The callback give you access to the current event and also the data passed
@@ -67,21 +69,17 @@ class Item extends Component<ItemProps> {
     super(props);
     const { disabled, hidden, nativeEvent, propsFromTrigger, data } = this.props;
 
-    this.isDisabled =
-      typeof disabled === 'function'
-        ? disabled({
+    const getBooleanPredicateValue = (predicateFunc: BooleanPredicate) => {
+      return typeof predicateFunc === 'function'
+        ? predicateFunc({
             event: nativeEvent as TriggerEvent,
             props: { ...propsFromTrigger, ...data }
           })
-        : disabled;
+        : predicateFunc;
+    }
 
-    this.isHidden =
-      typeof hidden === "function"
-        ? hidden({
-            event: nativeEvent as TriggerEvent,
-            props: { ...propsFromTrigger, ...data },
-          })
-        : hidden;
+    this.isDisabled = getBooleanPredicateValue(disabled)
+    this.isHidden = getBooleanPredicateValue(hidden)
   }
 
   handleClick = (e: React.MouseEvent) => {


### PR DESCRIPTION
Useful when you need to conditionally display menu items.
For example, multiple `MenuProvider`'s is passing different data to one `Menu` component.