### PR TITLE
Pass item id to `onClick()` handler and `hidden`/`disabled` predicates

### DIFF
--- a/src/components/Item.tsx
+++ b/src/components/Item.tsx
@@ -82,6 +82,7 @@ export interface ItemProps
 }
 
 export const Item: React.FC<ItemProps> = ({
+  id,
   children,
   className,
   style,
@@ -98,6 +99,7 @@ export const Item: React.FC<ItemProps> = ({
     data,
     triggerEvent: triggerEvent as HandlerParamsEvent,
     props: propsFromTrigger,
+    itemId: id,
   };
   const isDisabled = getPredicateValue(disabled, handlerParams);
   const isHidden = getPredicateValue(hidden, handlerParams);

--- a/src/components/Item.tsx
+++ b/src/components/Item.tsx
@@ -96,10 +96,10 @@ export const Item: React.FC<ItemProps> = ({
 }) => {
   const refTracker = useRefTrackerContext();
   const handlerParams = {
+    id,
     data,
     triggerEvent: triggerEvent as HandlerParamsEvent,
     props: propsFromTrigger,
-    itemId: id,
   };
   const isDisabled = getPredicateValue(disabled, handlerParams);
   const isHidden = getPredicateValue(hidden, handlerParams);

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -92,6 +92,7 @@ export type PredicateParams<Props = any, Data = any> = HandlerParams<
  */
 export interface ItemParams<Props = any, Data = any>
   extends HandlerParams<Props, Data> {
+  itemId: string;
   event:
     | React.MouseEvent<HTMLElement>
     | React.TouchEvent<HTMLElement>

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -32,6 +32,11 @@ export type MenuId = string | number;
  */
 interface HandlerParams<Props = any, Data = any> {
   /**
+   * The id of the item when provided
+   */
+   id?:string;
+   
+  /**
    * The event that triggered the context menu
    */
   triggerEvent: HandlerParamsEvent;
@@ -92,7 +97,6 @@ export type PredicateParams<Props = any, Data = any> = HandlerParams<
  */
 export interface ItemParams<Props = any, Data = any>
   extends HandlerParams<Props, Data> {
-  itemId: string;
   event:
     | React.MouseEvent<HTMLElement>
     | React.TouchEvent<HTMLElement>


### PR DESCRIPTION
I couldn't find anywhere in the documentation how to easily access the item id from the `hidden`/`disabled` predicates, so I made this very simple modification to avoid having to use the `data` prop from the `Item` component.

This is also useful when dealing with the `onClick()` handler, although the improvement is minor.
Instead of having something like:

```js
function handleOnClick({ props, event }) {
  const itemId = event.currentTarget.id;
  console.log(itemId);
  ...
}
```
we can access the item id directly like this:
```js
function handleOnClick({ props, event, itemId }) {
  console.log(itemId);
  ...
}
```

Where this feature seems very useful (at least in my use case) is when using the `hidden`/`disabled` predicates.
Instead of having to use the `data` prop when creating the item element, we can just simply use the item id.