### PR TITLE
Prob: Cannot hide Separator.

### DIFF
--- a/src/components/Separator.tsx
+++ b/src/components/Separator.tsx
@@ -1,7 +1,47 @@
 import React from 'react';
 
+import { BooleanPredicate, HandlerParamsEvent, InternalProps } from '../types';
+import { getPredicateValue } from './utils';
+
 import { STYLE } from '../constants';
 
-export function Separator() {
+export interface SeparatorProps
+  extends InternalProps {
+  /**
+   * Passed to the `Separator` hidden predicate. Accessible via `data`
+   */
+  data?: any;
+
+  /**
+   * Hide the `Separator`. If a function is used, a boolean must be returned
+   *
+   * @param props The props passed when you called `show(e, {props: yourProps})`
+   * @param data The data defined on the `Separator`
+   * @param triggerEvent The event that triggered the context menu
+   *
+   *
+   * ```
+   * function isSeparatorHidden({ triggerEvent, props, data }: PredicateParams<type of props, type of data>): boolean
+   * <Separator hidden={isSeparatorHidden} data={data}/>
+   * ```
+   */
+  hidden?: BooleanPredicate;
+}
+
+export const Separator: React.FC<SeparatorProps> = ({
+  triggerEvent,
+  data,
+  propsFromTrigger,
+  hidden = false
+}) => {
+  const handlerParams = {
+    data,
+    triggerEvent: triggerEvent as HandlerParamsEvent,
+    props: propsFromTrigger,
+  };
+  const isHidden = getPredicateValue(hidden, handlerParams);
+
+  if (isHidden) return null;
+
   return <div className={STYLE.separator} />;
 }


### PR DESCRIPTION
Solv: Add support for hidden predicate to Separator.

While this is a pull request, it's more of an ask to support the `hidden` attribute on the `Separator`. The use case is that sometimes all the things after the `Separator` are hidden (an empty section), so it would be visually appropriate to not display the separator at all.

I think the changes here are all that's required for implementation? (aside from docs, etc...)