### PR TITLE
Add escape hatch for disabling "stop propagation"

### DIFF
--- a/src/components/Menu.tsx
+++ b/src/components/Menu.tsx
@@ -193,8 +193,16 @@ export const Menu: React.FC<MenuProps> = ({
     };
   }, [state.visible, menuController, preventDefaultOnKeydown]);
 
-  function show({ event, props, position }: ShowContextMenuParams) {
-    event.stopPropagation();
+  function show({
+    event,
+    props,
+    position,
+    disableEventPropagation = true,
+  }: ShowContextMenuParams) {
+    // If the underlying element relies on the click event to be propagated, you can disable the "stop propagation" of the event.
+    if (disableEventPropagation) {
+      event.stopPropagation();
+    }
     const p = position || getMousePosition(event);
     // check boundaries when the menu is already visible
     const { x, y } = checkBoundaries(p.x, p.y);

--- a/src/core/contextMenu.ts
+++ b/src/core/contextMenu.ts
@@ -12,6 +12,7 @@ export interface ContextMenu {
 export interface ShowContextMenuParams<TProps = unknown> {
   id: MenuId;
   event: TriggerEvent;
+  disableEventPropagation?: boolean;
   props?: TProps;
   position?: {
     x: number;
@@ -20,13 +21,14 @@ export interface ShowContextMenuParams<TProps = unknown> {
 }
 
 const contextMenu: ContextMenu = {
-  show({ event, id, props, position }) {
+  show({ event, id, props, position, disableEventPropagation }) {
     if (event.preventDefault) event.preventDefault();
 
     eventManager.emit(EVENT.HIDE_ALL).emit(id, {
       event: (event as SyntheticEvent).nativeEvent || event,
       props,
       position,
+      disableEventPropagation,
     });
   },
   hideAll() {


### PR DESCRIPTION
First of all: Thanks for the great work on this library! It solves so much of our use case. This PR is a mere addition (backwards compatible, and opt-in) to allow event to still propagate when opening the menu, so that "underlying elements" that rely on `mouseUp` or similar may still function.